### PR TITLE
fix invalid_nonce for long URLs

### DIFF
--- a/src/http_helpers.cpp
+++ b/src/http_helpers.cpp
@@ -334,6 +334,9 @@ namespace modauthopenid {
     } else if(r->method_number == M_POST && get_post_data(r, query)) {
       debug("Request POST params: " + query);
       params = parse_query_string(query);
+      if (r->args != NULL) {
+        merge_params(parse_query_string(string(r->args)), params);
+      }
     }
   };
   


### PR DESCRIPTION
fix a problem where long URLs triggers invalid_nonce because params are not extracted from URI in POST requests
