### PR TITLE
fix build error in src/mod_auth_openid.cpp: "APR_ARRAY_IDX" not declared

### DIFF
--- a/src/mod_auth_openid.cpp
+++ b/src/mod_auth_openid.cpp
@@ -31,6 +31,10 @@ Created by bmuller <bmuller@butterfat.net>
 #define APWARN(r, msg, ...) ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, msg, __VA_ARGS__);
 #define APERR(r, msg, ...) ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, msg, __VA_ARGS__);
 
+#ifndef APR_ARRAY_IDX
+#define APR_ARRAY_IDX(ary,i,type) (((type *)(ary)->elts)[i])
+#endif
+
 extern "C" module AP_MODULE_DECLARE_DATA authopenid_module;
 
 typedef struct {


### PR DESCRIPTION
fix build error: "APR_ARRAY_IDX" not declared which was caused by apr version < 1.3
