### PR TITLE
Changed Cache-Control header to be sent via err_headers_out

### DIFF
--- a/src/http_helpers.cpp
+++ b/src/http_helpers.cpp
@@ -82,7 +82,7 @@ namespace modauthopenid {
     } else {
       debug("Redirecting via HTTP_MOVED_TEMPORARILY to: " + location);
       apr_table_set(r->headers_out, "Location", location.c_str());
-      apr_table_setn(r->headers_out, "Cache-Control", "no-cache");
+      apr_table_setn(r->err_headers_out, "Cache-Control", "no-cache");
       return HTTP_MOVED_TEMPORARILY;
     }
   };


### PR DESCRIPTION
This pull request is in response to https://github.com/bmuller/mod_auth_openid/issues/44.  Cache-Control headers were not being sent out.  Using r->err_headers_out instead of r->headers_out properly sets the Cache-Control.  I am using this fork in place and it has corrected the issue in our production system.  Cache-Control headers are now observed.  

SB
